### PR TITLE
MSYS?: consider as is_cygwin

### DIFF
--- a/Ack.pm
+++ b/Ack.pm
@@ -46,7 +46,7 @@ BEGIN {
     $output_to_pipe  = not -t *STDOUT;
     $is_filter_mode = -p STDIN;
 
-    $is_cygwin       = ($^O eq 'cygwin');
+    $is_cygwin       = ($^O eq 'cygwin' || $^O eq 'msys');
     $is_windows      = ($^O eq 'MSWin32');
     $dir_sep_chars   = $is_windows ? quotemeta( '\\/' ) : quotemeta( File::Spec->catfile( '', '' ) );
 }

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -43,7 +43,7 @@ sub is_windows {
 }
 
 sub is_cygwin {
-    return $^O eq 'cygwin';
+    return $^O eq 'cygwin' or $^O eq 'msys';
 }
 
 sub is_empty_array {


### PR DESCRIPTION
I work on the MSYS2 project ( https://sourceforge.net/projects/msys2/ ) which takes Windows and adds Arch Linux's pacman tool to it to give it a good (IMHO) package development and management system. We have our own OS identifier for perl of "msys". For the purposes of our MSYS2 ack, we need to be considered to be like Cygwin (MSYS? is a fork of Cygwin).
