### PR TITLE
removed -T in SheBang because of failed tests on Win32

### DIFF
--- a/t/ack-match.t
+++ b/t/ack-match.t
@@ -1,4 +1,4 @@
-#!perl -T
+#!perl 
 
 use strict;
 use warnings;

--- a/t/ack-o.t
+++ b/t/ack-o.t
@@ -1,4 +1,4 @@
-#!perl -T
+#!perl 
 
 use warnings;
 use strict;

--- a/t/config-finder.t
+++ b/t/config-finder.t
@@ -1,4 +1,4 @@
-#!perl -T
+#!perl 
 
 use strict;
 use warnings;


### PR DESCRIPTION
The tests for App::Ack failed on my Windows 7 system with all Strawberry Perl versions (5.14 - 5.20).

I figured out, that the problem is the taint switch -T in shebang of these three tests. 

If in taintmode File::Temp->tempdir does not create a directory in temporary directory of the user or system,  but wrong in \ of drive, on which the tests for App::Ack are running.
Becaus of this the tests fails.

Please check this.
