### PR TITLE
Option to ignore IDEA IntelliJ files

### DIFF
--- a/ConfigDefault.pm
+++ b/ConfigDefault.pm
@@ -270,6 +270,10 @@ sub _options_block {
 # HTML
 --type-add=html:ext:htm,html
 
+# IDEA IntelliJ
+# http://www.jetbrains.com/idea/
+--type-add=idea:ext:iml
+
 # Jade
 # http://jade-lang.com/
 --type-add=jade:ext:jade

--- a/t/ack-filetypes.t
+++ b/t/ack-filetypes.t
@@ -31,6 +31,7 @@ groovy
 haskell
 hh
 html
+idea
 java
 js
 json


### PR DESCRIPTION
Hello @petdance ,

I use ack all the time, but find myself needing to filter out IntelliJ project files, so I added that ability. Please feel free to merge it in if you think it would be useful for others.