### PR TITLE
Reduce unnessecary big regexps

### DIFF
--- a/ack
+++ b/ack
@@ -66,13 +66,13 @@ MAIN: {
         last if ( $arg eq '--' );
 
         # Get the --thpppt, --bar, --cathy checking out of the way.
-        $arg =~ /^--th[pt]+t+$/ and App::Ack::_thpppt($arg);
-        $arg eq '--bar'         and App::Ack::_bar();
-        $arg eq '--cathy'       and App::Ack::_cathy();
+        $arg =~ /^--th[pt]+t$/ and App::Ack::_thpppt($arg);
+        $arg eq '--bar'        and App::Ack::_bar();
+        $arg eq '--cathy'      and App::Ack::_cathy();
 
         # See if we want to ignore the environment. (Don't tell Al Gore.)
-        $arg eq '--env'         and $env_is_usable = 1;
-        $arg eq '--noenv'       and $env_is_usable = 0;
+        $arg eq '--env'        and $env_is_usable = 1;
+        $arg eq '--noenv'      and $env_is_usable = 0;
     }
 
     if ( !$env_is_usable ) {


### PR DESCRIPTION
Since the regular expression should contain [pt]+, means that there might be an arbitrary number of t:s at the end. The following t+ means the regexp should end with a t. Removing the + means the t:s prior is just contained in the [pt]+

This reduces the file size with 1 byte, which, even though it's really unlikely, means having space for this app or not.

THPPPTPTPTPTPPTT!