### PR TITLE
Add XML Schema Documents (.xsd) to the XML filetype

### DIFF
--- a/ConfigDefault.pm
+++ b/ConfigDefault.pm
@@ -412,7 +412,7 @@ sub _options_block {
 
 # XML
 # http://www.w3.org/TR/REC-xml/
---type-add=xml:ext:xml,dtd,xsl,xslt,ent
+--type-add=xml:ext:xml,dtd,xsd,xsl,xslt,ent
 --type-add=xml:firstlinematch:/<[?]xml/
 
 # YAML


### PR DESCRIPTION
Include XML Schema Documents in the XML filetype.