### PR TITLE
Add new 'i18n' filetype for translation source files

### DIFF
--- a/ConfigDefault.pm
+++ b/ConfigDefault.pm
@@ -270,6 +270,11 @@ sub _options_block {
 # HTML
 --type-add=html:ext:htm,html
 
+# Internationalisation (i18n)
+#   GNU gettext https://www.gnu.org/software/gettext/
+#   Qt Linguist http://doc.qt.io/qt-5/qtlinguist-index.html
+--type-add=i18n:ext:po,ts
+
 # Jade
 # http://jade-lang.com/
 --type-add=jade:ext:jade

--- a/t/ack-filetypes.t
+++ b/t/ack-filetypes.t
@@ -30,6 +30,7 @@ go
 groovy
 haskell
 hh
+i18n
 html
 java
 js


### PR DESCRIPTION
This update adds support for a new 'linguist' filetype which covers
Qt Linguist translation source (.ts) files, used to provide i18n
support to Qt applications.