### PR TITLE
dev/timings.pl should exit and warn if cannot find parrot

### DIFF
--- a/dev/timings.pl
+++ b/dev/timings.pl
@@ -15,7 +15,9 @@ use Time::HiRes qw(gettimeofday tv_interval);
 
 my $SOURCE_DIR = File::Spec->catdir($ENV{HOME}, 'parrot');
 
--d $SOURCE_DIR or die "Expecting to find parrot in $SOURCE_DIR - get it from github.com/parrot/parrot";
+unless ( -d $SOURCE_DIR ) {
+    die "Expecting to find parrot in $SOURCE_DIR - get it from github.com/parrot/parrot";
+}
 
 sub grab_versions {
     my @acks = @_;

--- a/dev/timings.pl
+++ b/dev/timings.pl
@@ -15,6 +15,8 @@ use Time::HiRes qw(gettimeofday tv_interval);
 
 my $SOURCE_DIR = File::Spec->catdir($ENV{HOME}, 'parrot');
 
+-d $SOURCE_DIR or die "Expecting to find parrot in $SOURCE_DIR - get it from github.com/parrot/parrot";
+
 sub grab_versions {
     my @acks = @_;
 


### PR DESCRIPTION
I was confused as to why I was getting `x_x` in all my timings results - @hoelzro pointed out it was expecting to find a copy of parrot, which I hadn't realised before.

As a developer just starting to use timings, or using it on a new machine, this warning will tell me what I need to get and where to put it.