### PR TITLE
Add CVS merge backups to ignore list

### DIFF
--- a/ConfigDefault.pm
+++ b/ConfigDefault.pm
@@ -131,6 +131,9 @@ sub _options_block {
 # core dumps
 --ignore-file=match:/core\.\d+$/
 
+# CVS merge backups
+--ignore-file=match:/^.#.+/
+
 # minified Javascript
 --ignore-file=match:/[.-]min[.]js$/
 --ignore-file=match:/[.]js[.]min$/

--- a/ConfigDefault.pm
+++ b/ConfigDefault.pm
@@ -132,7 +132,7 @@ sub _options_block {
 --ignore-file=match:/core\.\d+$/
 
 # CVS merge backups
---ignore-file=match:/^.#.+/
+--ignore-file=match:/^\.#.+/
 
 # minified Javascript
 --ignore-file=match:/[.-]min[.]js$/


### PR DESCRIPTION
Yes, some of us still use CVS.

History lesson:

When a `cvs update` merges changes into a locally-modified file, it
saves a copy of the file by renaming it so it looks like `.#file.c.1.7`.

Typically nobody cares about these files.