### PR TITLE
(Minor) Add missing Getopt::Long 2.38 update

### DIFF
--- a/ConfigLoader.pm
+++ b/ConfigLoader.pm
@@ -9,7 +9,7 @@ use App::Ack::ConfigFinder ();
 use App::Ack::Filter;
 use App::Ack::Filter::Default;
 use Carp 1.04 ();
-use Getopt::Long 2.35 ();
+use Getopt::Long 2.38 ();
 use Text::ParseWords 3.1 ();
 
 =head1 FUNCTIONS


### PR DESCRIPTION
Goes with https://github.com/petdance/ack2/commit/9f6c3882c2088d261f00a7789134868c0b0e767f.