### PR TITLE
Specify --sort-files in all test cases that scan the t/text directory.

### DIFF
--- a/t/ack-1.t
+++ b/t/ack-1.t
@@ -17,7 +17,7 @@ SINGLE_TEXT_MATCH: {
     );
 
     my @files = qw( t/text );
-    my @args = qw( Sue -1 -h );
+    my @args = qw( Sue -1 -h --sort-files );
     my @results = run_ack( @args, @files );
 
     lists_match( \@results, \@expected, 'Looking for first instance of Sue!' );

--- a/t/ack-c.t
+++ b/t/ack-c.t
@@ -15,7 +15,7 @@ DASH_L: {
         t/text/science-of-myth.txt
     );
 
-    my @args  = qw( religion -i -l );
+    my @args  = qw( religion -i -l --sort-files );
     my @files = qw( t/text );
 
     ack_sets_match( [ @args, @files ], \@expected, 'Looking for religion with -l' );
@@ -39,7 +39,7 @@ DASH_CAPITAL_L: {
 
     for my $switches ( @switches ) {
         my @files = qw( t/text );
-        my @args  = ( 'religion', @{$switches} );
+        my @args  = ( 'religion', @{$switches}, '--sort-files' );
 
         ack_sets_match( [ @args, @files ], \@expected, "Looking for religion with @{$switches}" );
     }
@@ -65,7 +65,7 @@ DASH_LV: {
 
     for my $switches ( @switches ) {
         my @files = qw( t/text );
-        my @args  = ( 'religion', @{$switches} );
+        my @args  = ( 'religion', @{$switches}, '--sort-files' );
 
         ack_sets_match( [ @args, @files ], \@expected, '-l -v will mostly likely match all input files' );
     }
@@ -83,7 +83,7 @@ DASH_C: {
         t/text/shut-up-be-happy.txt:0
     );
 
-    my @args  = qw( boy -i -c );
+    my @args  = qw( boy -i -c --sort-files );
     my @files = qw( t/text );
 
     ack_sets_match( [ @args, @files ], \@expected, 'Boy counts' );
@@ -94,7 +94,7 @@ DASH_LC: {
         t/text/science-of-myth.txt:2
     );
 
-    my @args  = qw( religion -i -l -c );
+    my @args  = qw( religion -i -l -c --sort-files );
     my @files = qw( t/text );
 
     ack_sets_match( [ @args, @files ], \@expected, 'Religion counts -l -c' );

--- a/t/ack-g.t
+++ b/t/ack-g.t
@@ -157,7 +157,7 @@ subtest '-Q works on -g' => sub {
     $regex = 'of';
 
     @files = qw( t/text );
-    @args  = ( '-Q', '-g', $regex );
+    @args  = ( '-Q', '-g', $regex, '--sort-files' );
 
     ack_sets_match( [ @args, @files ], \@expected, "Looking for $regex with quotemeta." );
 };
@@ -166,7 +166,7 @@ subtest '-w works on -g' => sub {
     my @expected = qw();
     my $regex = 'free';
 
-    my @args  = ( '-w', '-g', $regex ); # The -w means "free" won't match "freedom"
+    my @args  = ( '-w', '-g', $regex, '--sort-files' ); # The -w means "free" won't match "freedom"
     my @files = qw( t/text/ );
 
     ack_sets_match( [ @args, @files ], \@expected, "Looking for $regex with '-w'." );
@@ -179,7 +179,7 @@ subtest '-w works on -g' => sub {
     $regex = 'of';
 
     @files = qw( t/text );
-    @args  = ( '-w', '-g', $regex );
+    @args  = ( '-w', '-g', $regex, '--sort-files' );
 
     ack_sets_match( [ @args, @files ], \@expected, "Looking for $regex with '-w'." );
 };
@@ -194,7 +194,7 @@ subtest '-v works on -g' => sub {
     );
     my $file_regex = 'of';
 
-    my @args  = ( '-v', '-g', $file_regex );
+    my @args  = ( '-v', '-g', $file_regex, '--sort-files' );
     my @files = qw( t/text/ );
 
     ack_sets_match( [ @args, @files ], \@expected, "Looking for file names that do not match $file_regex" );

--- a/t/ack-interactive.t
+++ b/t/ack-interactive.t
@@ -19,7 +19,7 @@ plan tests => 6;
 prep_environment();
 
 INTERACTIVE_GROUPING_NOCOLOR: {
-    my @args  = qw( Sue --nocolor );
+    my @args  = qw( Sue --nocolor --sort-files );
     my @files = qw( t/text );
 
     my $output = run_ack_interactive(@args, @files);
@@ -37,7 +37,7 @@ END_OUTPUT
 }
 
 INTERACTIVE_NOHEADING_NOCOLOR: {
-    my @args  = qw( Sue --nocolor --noheading);
+    my @args  = qw( Sue --nocolor --noheading --sort-files );
     my @files = qw( t/text );
 
     my $output = run_ack_interactive(@args, @files);
@@ -54,7 +54,7 @@ END_OUTPUT
 }
 
 INTERACTIVE_NOGROUP_NOCOLOR: {
-    my @args  = qw( Sue --nocolor --nogroup);
+    my @args  = qw( Sue --nocolor --nogroup --sort-files );
     my @files = qw( t/text );
 
     my $output = run_ack_interactive(@args, @files);
@@ -71,7 +71,7 @@ END_OUTPUT
 }
 
 INTERACTIVE_GROUPING_COLOR: {
-    my @args  = qw( Sue ); # --color is on by default
+    my @args  = qw( Sue --sort-files ); # --color is on by default
     my @files = qw( t/text );
 
     my $CFN      = color 'bold green';

--- a/t/ack-m.t
+++ b/t/ack-m.t
@@ -11,7 +11,7 @@ use File::Next;
 
 prep_environment();
 
-my @text  = map {
+my @text  = sort map {
     untaint($_)
 } glob( 't/text/s*.txt' );
 

--- a/t/ack-match.t
+++ b/t/ack-match.t
@@ -91,6 +91,7 @@ sub test_match {
 
     my $regex = shift;
     my @args  = @_;
+    push @args, '--sort-files';
 
     return subtest "test_match( @args )" => sub {
         my @files = ( 't/text' );

--- a/t/ack-o.t
+++ b/t/ack-o.t
@@ -64,7 +64,7 @@ EOF
 # Give an output function and find match in multiple files (so print filenames, just like grep -o).
 WITH_OUTPUT: {
     my @files = qw( t/text/ );
-    my @args = qw/ --output=x$1x question(\\S+) /;
+    my @args = qw/ --output=x$1x question(\\S+) --sort-files /;
 
     my @target_file = (
         File::Next::reslash( 't/text/science-of-myth.txt' ),
@@ -81,7 +81,7 @@ WITH_OUTPUT: {
 
 OUTPUT_DOUBLE_QUOTES: {
     my @files = qw( t/text/ );
-    my @args  = ( '--output="$1"', 'question(\\S+)' );
+    my @args  = ( '--output="$1"', 'question(\\S+)', '--sort-files' );
 
     my @target_file = (
         File::Next::reslash( 't/text/science-of-myth.txt' ),
@@ -117,7 +117,7 @@ PROJECT_ACKRC_OUTPUT_FORBIDDEN: {
 
 HOME_ACKRC_OUTPUT_PERMITTED: {
     my @files = untaint( File::Spec->rel2abs('t/text/') );
-    my @args = qw/ --env question(\\S+) /;
+    my @args = qw/ --env question(\\S+) --sort-files /;
 
     write_file(File::Spec->catfile($tempdir->dirname, '.ackrc'), "--output=foo\n");
     chdir File::Spec->catdir($tempdir->dirname, 'subdir');
@@ -133,7 +133,7 @@ HOME_ACKRC_OUTPUT_PERMITTED: {
 
 ACKRC_ACKRC_OUTPUT_PERMITTED: {
     my @files = untaint( File::Spec->rel2abs('t/text/') );
-    my @args = qw/ --env question(\\S+) /;
+    my @args = qw/ --env question(\\S+) --sort-files /;
 
     write_file(File::Spec->catfile($tempdir->dirname, '.ackrc'), "--output=foo\n");
     chdir File::Spec->catdir($tempdir->dirname, 'subdir');

--- a/t/ack-pager.t
+++ b/t/ack-pager.t
@@ -20,7 +20,7 @@ plan tests => 15;
 prep_environment();
 
 NO_PAGER: {
-    my @args = qw(--nocolor Sue t/text);
+    my @args = qw(--nocolor --sort-files Sue t/text);
 
     my @expected = split /\n/, <<'END_TEXT';
 t/text/boy-named-sue.txt
@@ -39,7 +39,7 @@ END_TEXT
 }
 
 PAGER: {
-    my @args = qw(--nocolor --pager=./test-pager Sue t/text);
+    my @args = qw(--nocolor --pager=./test-pager --sort-files Sue t/text);
 
     my @expected = split /\n/, <<'END_TEXT';
 t/text/boy-named-sue.txt
@@ -58,7 +58,7 @@ END_TEXT
 }
 
 PAGER_WITH_OPTS: {
-    my @args = ('--nocolor', '--pager=./test-pager --skip=2', 'Sue', 't/text');
+    my @args = ('--nocolor', '--pager=./test-pager --skip=2', '--sort-files', 'Sue', 't/text');
 
     my @expected = split /\n/, <<'END_TEXT';
 t/text/boy-named-sue.txt
@@ -73,7 +73,7 @@ END_TEXT
 }
 
 FORCE_NO_PAGER: {
-    my @args = ('--nocolor', '--pager=./test-pager --skip=2', '--nopager',
+    my @args = ('--nocolor', '--pager=./test-pager --skip=2', '--nopager', '--sort-files',
         'Sue', 't/text');
 
     my @expected = split /\n/, <<'END_TEXT';
@@ -96,7 +96,7 @@ PAGER_ENV: {
     local $ENV{'ACK_PAGER'} = './test-pager --skip=2';
     local $TODO             = q{Setting ACK_PAGER in tests won't work for the time being};
 
-    my @args = ('--nocolor', 'Sue', 't/text');
+    my @args = ('--nocolor', '--sort-files', 'Sue', 't/text');
 
     my @expected = split /\n/, <<'END_TEXT';
 t/text/boy-named-sue.txt
@@ -113,7 +113,7 @@ END_TEXT
 PAGER_ENV_OVERRIDE: {
     local $ENV{'ACK_PAGER'} = './test-pager --skip=2';
 
-    my @args = ('--nocolor', '--nopager', 'Sue', 't/text');
+    my @args = ('--nocolor', '--nopager', '--sort-files', 'Sue', 't/text');
 
     my @expected = split /\n/, <<'END_TEXT';
 t/text/boy-named-sue.txt
@@ -132,7 +132,7 @@ END_TEXT
 }
 
 PAGER_ACKRC: {
-    my @args = ('--nocolor', 'Sue', 't/text');
+    my @args = ('--nocolor', '--sort-files', 'Sue', 't/text');
 
     my $ackrc = <<'END_ACKRC';
 --pager=./test-pager --skip=2
@@ -153,7 +153,7 @@ END_TEXT
 }
 
 PAGER_ACKRC_OVERRIDE: {
-    my @args = ('--nocolor', '--nopager', 'Sue', 't/text');
+    my @args = ('--nocolor', '--nopager', '--sort-files', 'Sue', 't/text');
 
     my $ackrc = <<'END_ACKRC';
 --pager=./test-pager --skip=2
@@ -180,7 +180,7 @@ END_TEXT
 PAGER_NOENV: {
     local $ENV{'ACK_PAGER'} = './test-pager --skip=2';
 
-    my @args = ('--nocolor', '--noenv', 'Sue', 't/text');
+    my @args = ('--nocolor', '--noenv', '--sort-files', 'Sue', 't/text');
 
     my @expected = split /\n/, <<'END_TEXT';
 t/text/boy-named-sue.txt

--- a/t/ack-v.t
+++ b/t/ack-v.t
@@ -32,7 +32,7 @@ DASH_L: {
         t/text/shut-up-be-happy.txt
     );
 
-    my @args  = qw( religion -i -v -l );
+    my @args  = qw( religion -i -v -l --sort-files );
     my @files = qw( t/text );
 
     ack_sets_match( [ @args, @files ], \@expected, 'No religion please' );
@@ -52,7 +52,7 @@ DASH_C: {
         t/text/shut-up-be-happy.txt:26
     );
 
-    my @args  = qw( religion -i -v -c );
+    my @args  = qw( religion -i -v -c --sort-files );
     my @files = qw( t/text );
 
     ack_sets_match( [ @args, @files ], \@expected, 'Non-religion counts' );

--- a/t/ack-w.t
+++ b/t/ack-w.t
@@ -17,7 +17,7 @@ TRAILING_PUNC: {
     );
 
     my @files = qw( t/text );
-    my @args = qw( Sue! -w -h );
+    my @args = qw( Sue! -w -h --sort-files );
 
     ack_lists_match( [ @args, @files ], \@expected, 'Looking for Sue!' );
 }
@@ -29,7 +29,7 @@ TRAILING_METACHAR_BACKSLASH_W: {
     );
 
     my @files = qw( t/text );
-    my @args = qw( mu\w -w -h );
+    my @args = qw( mu\w -w -h --sort-files );
 
     ack_lists_match( [ @args, @files ], \@expected, 'Looking for mu\\w' );
 }
@@ -43,7 +43,7 @@ TRAILING_METACHAR_DOT: {
     );
 
     my @files = qw( t/text );
-    my @args = ( 'mu.', qw( -w -h ) );
+    my @args = ( 'mu.', qw( -w -h --sort-files ) );
 
     ack_lists_match( [ @args, @files ], \@expected, 'Looking for mu.' );
 }

--- a/t/ack-x.t
+++ b/t/ack-x.t
@@ -95,7 +95,7 @@ $science:23:Somehow no matter what the world keeps turning
 EOF
 
 my $perl = caret_X();
-my @lhs_args = ( $perl, '-Mblib', build_ack_invocation( '-g', 'of', 't/text' ) );
+my @lhs_args = ( $perl, '-Mblib', build_ack_invocation( '--sort-files', '-g', 'of', 't/text' ) );
 my @rhs_args = ( $perl, '-Mblib', build_ack_invocation( '-x', 'the' ) ); # for now
 
 if ( $ENV{'ACK_TEST_STANDALONE'} ) {

--- a/t/anchored.t
+++ b/t/anchored.t
@@ -14,7 +14,7 @@ prep_environment();
 my @files = qw( t/text );
 
 FRONT_ANCHORED: {
-    my @args  = qw( -h -i ^science );
+    my @args  = qw( --sort-files -h -i ^science );
 
     my @expected = split( /\n/, <<'EOF' );
 Science and religion are not mutually exclusive
@@ -24,7 +24,7 @@ EOF
 }
 
 BACK_ANCHORED: {
-    my @args  = qw( -h -i done$ );
+    my @args  = qw( --sort-files -h -i done$ );
 
     my @expected = split( /\n/, <<'EOF' );
 Through all kinds of weather and everything we done
@@ -35,7 +35,7 @@ EOF
 }
 
 UNANCHORED: {
-    my @args  = qw( -h -i science );
+    my @args  = qw( --sort-files -h -i science );
 
     my @expected = split( /\n/, <<'EOF' );
 Science and religion are not mutually exclusive

--- a/t/context.t
+++ b/t/context.t
@@ -44,7 +44,7 @@ EOF
 
     my $regex = 'laugh';
     my @files = qw( t/text );
-    my @args = ( '-B2', $regex );
+    my @args = ( '--sort-files', '-B2', $regex );
 
     ack_lists_match( [ @args, @files ], \@expected, "Looking for $regex - before with line numbers" );
 }

--- a/t/highlighting.t
+++ b/t/highlighting.t
@@ -15,7 +15,7 @@ prep_environment();
 my @HIGHLIGHT = qw( --color --group --sort-files );
 
 BASIC: {
-    my @args  = qw( beliefs t/text/ );
+    my @args  = qw( --sort-files beliefs t/text/ );
 
     my $expected_original = <<'END';
 <t/text/science-of-myth.txt>
@@ -34,7 +34,7 @@ END
 
 
 METACHARACTERS: {
-    my @args  = qw( \w*din\w* t/text/ );
+    my @args  = qw( --sort-files \w*din\w* t/text/ );
     my $expected_original = <<'END';
 <t/text/4th-of-july.txt>
 {24}:(Riding) shotgun from town to town
@@ -58,7 +58,7 @@ END
 
 
 CONTEXT: {
-    my @args  = qw( love -C1 t/text/ );
+    my @args  = qw( --sort-files love -C1 t/text/ );
 
     my $expected_original = <<'END';
 <t/text/4th-of-july.txt>


### PR DESCRIPTION
This makes them more robust if the order of the files on disk changes.
As it happens, they were all expecting the files sorted by name
(which is the default if you make a git checkout, I think).

As suggested by petdance in https://github.com/petdance/ack2/pull/560#issuecomment-162003655