### PR TITLE
support for searching edn, clojurescipt, and cljc files

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,6 +6,8 @@ NEXT
 [INTERNALS]
 Added test to test --output. Thanks, Varadinsky! (GH #587, GH #590)
 
+[ENHANCEMENTS]
+Include cljs, cljc, and edn files with the --clojure flag.
 
 2.15_02 Thu Dec 17 15:51:15 CST 2015
 ====================================

--- a/ConfigDefault.pm
+++ b/ConfigDefault.pm
@@ -205,7 +205,7 @@ sub _options_block {
 
 # Clojure
 # http://clojure.org/
---type-add=clojure:ext:clj
+--type-add=clojure:ext:clj,cljs,edn,cljc
 
 # C
 # .xs are Perl C files


### PR DESCRIPTION
When using `--clojure` search 3 additions file types

`.edn` - A common clojure data format
`.cljs` - Clojurescript source
`.cljc`- [Hybrid clojure/clojurescript source](https://github.com/clojure/clojurescript/wiki/Using-cljc)