### PR TITLE
Fix some stray paragraphs in the man page.

### DIFF
--- a/ConfigLoader.pm
+++ b/ConfigLoader.pm
@@ -255,7 +255,7 @@ You may have options in a .ackrc, or in the ACKRC_OPTIONS environment variable.
 Try using the --dump flag.
 EOT
 
-=for Adding-Options
+=begin Adding-Options
 
     *** IF YOU ARE MODIFYING ACK PLEASE READ THIS ***
 
@@ -273,6 +273,8 @@ EOT
     * Go through the list of options already available, and consider
       whether your new option can be considered mutually exclusive
       with another option.
+
+=end Adding-Options
 
 =cut
 

--- a/ack
+++ b/ack
@@ -393,7 +393,7 @@ sub setup_line_context_for_file {
     return;
 }
 
-=for Developers
+=begin Developers
 
 This subroutine jumps through a number of optimization hoops to
 try to be fast in the more common use cases of ack.  For one thing,
@@ -404,6 +404,8 @@ and normal searching.  Any changes that happen to one should propagate
 to the others if they make sense.  The non-context branches also inline
 does_match for performance reasons; any relevant changes that happen here
 must also happen there.
+
+=end Developers
 
 =cut
 
@@ -759,11 +761,13 @@ sub print_line_if_context {
 
 # does_match() MUST have an $opt_regex set.
 
-=for Developers
+=begin Developers
 
 This subroutine is inlined a few places in print_matches_in_resource
 for performance reasons, so any changes here must be copied there as
 well.
+
+=end Developers
 
 =cut
 


### PR DESCRIPTION
To reproduce do “nroff -man blib/man1/ack.1 | less -isrr” and you'll
notice them. They were eliminated by converting from the POD ^=for
directive to the more robust =begin/=end.