### PR TITLE
Fix warning when rendering pod

### DIFF
--- a/ack
+++ b/ack
@@ -1050,7 +1050,11 @@ RESOURCES:
     App::Ack::exit_from_ack( $nmatches );
 }
 
+__END__
 
+=pod
+
+=encoding UTF-8
 
 =head1 NAME
 


### PR DESCRIPTION
    "Wide character in print at .../Pod/Text.pm line 286."
    from attempt to render characters that are not available in CP-1252. See RT#102631.