### PR TITLE
Graphviz filetypes and issue 615

### DIFF
--- a/ConfigDefault.pm
+++ b/ConfigDefault.pm
@@ -259,6 +259,10 @@ sub _options_block {
 # http://golang.org/
 --type-add=go:ext:go
 
+# Graphviz
+# http://www.graphviz.org
+--type-add=graphviz:ext:gv,dot
+
 # Groovy
 # http://groovy.codehaus.org/
 --type-add=groovy:ext:groovy,gtmpl,gpp,grunit,gradle

--- a/ack
+++ b/ack
@@ -606,7 +606,8 @@ sub print_line_with_options {
                     last if $-[0] == $+[0];
 
                     for ( my $i = 1; $i < @+; $i++ ) {
-                        my ( $match_start, $match_end ) = ( $-[$i], $+[$i] );
+                        # Fix issue 615 apparently
+                        my ( $match_start, $match_end ) = ( $-[$i] - 1, $+[$i] );
 
                         next unless defined($match_start);
                         next if $match_start < $previous_match_end;

--- a/ack
+++ b/ack
@@ -607,7 +607,7 @@ sub print_line_with_options {
 
                     for ( my $i = 1; $i < @+; $i++ ) {
                         # Fix issue 615 apparently
-                        my ( $match_start, $match_end ) = ( $-[$i] - 1, $+[$i] );
+                        my ( $match_start, $match_end ) = ( $-[$i] - 1, $+[$i-1] );
 
                         next unless defined($match_start);
                         next if $match_start < $previous_match_end;

--- a/ack
+++ b/ack
@@ -607,7 +607,7 @@ sub print_line_with_options {
 
                     for ( my $i = 1; $i < @+; $i++ ) {
                         # Fix issue 615 apparently
-                        my ( $match_start, $match_end ) = ( $-[$i] - 1, $+[$i-1] );
+                        my ( $match_start, $match_end ) = ( $-[$i-1], $+[$i-1] );
 
                         next unless defined($match_start);
                         next if $match_start < $previous_match_end;

--- a/t/ack-filetypes.t
+++ b/t/ack-filetypes.t
@@ -27,6 +27,7 @@ elisp
 erlang
 fortran
 go
+graphviz
 groovy
 haskell
 hh


### PR DESCRIPTION
Wanted to exclude dot (gv) files from ack's search. Added that.

Then read this: https://github.com/petdance/ack2/issues/615. 
I believe the offset will be plus one on the current iteration if input contains '()', hence always colouring whatever it's inside as it is the last match.
It is a very silly change, line 609:
```perl
my ( $match_start, $match_end ) = ( $-[$i-1], $+[$i-1] );
```
or just change the loop initial value to 0 instead of using 1 (if makes more sense to change it).

Now:
```bash
ack '(foo)bar' foo # Highlights "foobar"
ack 'is a (t.+t)' foo # Highlights "is a test"
ack 'is a ((((t)e)s)+t)' foo # Same as above
```

Regards.